### PR TITLE
Compatibility for PHP 8

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -53,7 +53,7 @@ class Server
 
     public function isStarted()
     {
-        return is_resource($this->socket);
+        return is_resource($this->socket) || $this->socket instanceof \Socket;
     }
 
     public function read()


### PR DESCRIPTION
See https://github.com/Seldaek/monolog/issues/1519

is_resource always returns false, adding an instanceof check ensures this works as intended in newer PHP Versions.